### PR TITLE
Remove domain of `name` property

### DIFF
--- a/fno.ttl
+++ b/fno.ttl
@@ -94,7 +94,6 @@
 
 :name
     rdf:type           owl:DatatypeProperty ;
-    rdfs:domain        :Function ;
     rdfs:range         xsd:string ;
     rdfs:subPropertyOf rdfs:label ;
     rdfs:label         "name"@en ;


### PR DESCRIPTION
Remove domain of `name` property since it can be property of `Function` as well as `Parameter` (but something with property `name` cannot be both `Function` and `Parameter`).